### PR TITLE
Make the addin more verbose re: what it's doing

### DIFF
--- a/R/assign_defaults.R
+++ b/R/assign_defaults.R
@@ -35,7 +35,7 @@ assign_defaults_addin <- function() {
 #' @rdname assign_defaults
 #' @export
 assign_defaults <- function(fun) {
-  fun_name <- deparse(substitute(fun))
+  fun_name <- as.character(substitute(fun))
   fun_fmls <- formals(fun)
 
   msg <- paste0(

--- a/R/assign_defaults.R
+++ b/R/assign_defaults.R
@@ -49,10 +49,8 @@ assign_defaults <- function(fun) {
     if (missing(val)) {
       fun_fmls[[i]] <- "<no assignment made>"
     } else {
-      if (is.language(val)) {
+      if (!is.null(val)) {
         fun_fmls[[i]] <- eval(val, envir = globalenv())
-      } else if (!is.null(val)) {
-        fun_fmls[[i]] <- val
       }
       assign(nm, fun_fmls[[i]], envir = globalenv())
     }

--- a/R/assign_defaults.R
+++ b/R/assign_defaults.R
@@ -35,15 +35,33 @@ assign_defaults_addin <- function() {
 #' @rdname assign_defaults
 #' @export
 assign_defaults <- function(fun) {
-  fmls <- formals(fun)
-  is_naked_name <- vapply(fmls, is.name, logical(1)) # fyi: this catches `...`
-  fmls <- fmls[!is_naked_name]
-  for (i in seq_along(fmls)) {
-    if (is.language(fmls[[i]])) {
-      thing <- eval(fmls[[i]], envir = globalenv())
+  fun_name <- deparse(substitute(fun))
+  fun_fmls <- formals(fun)
+
+  msg <- paste0(
+    "Setting formal arguments of ", fun_name, " to their default values\n"
+  )
+
+  for (i in seq_along(fun_fmls)) {
+    nm <- names(fun_fmls)[[i]]
+    val <- fun_fmls[[i]]
+
+    if (missing(val)) {
+      fun_fmls[[i]] <- "<no assignment made>"
     } else {
-      thing <- fmls[[i]]
+      if (is.language(val)) {
+        fun_fmls[[i]] <- eval(val, envir = globalenv())
+      } else if (!is.null(val)) {
+        fun_fmls[[i]] <- val
+      }
+      assign(nm, fun_fmls[[i]], envir = globalenv())
     }
-    assign(names(fmls)[[i]], thing, envir = globalenv())
   }
+
+  msg <- c(
+    msg,
+    paste0(format(names(fun_fmls), justify = 'right'), ": ", fun_fmls, "\n")
+  )
+  message(msg)
+  invisible()
 }

--- a/R/assign_defaults.R
+++ b/R/assign_defaults.R
@@ -39,7 +39,7 @@ assign_defaults <- function(fun) {
   fun_fmls <- formals(fun)
 
   msg <- paste0(
-    "Setting formal arguments of ", fun_name, " to their default values\n"
+    "Setting formal arguments of `", fun_name, "()` to their default values\n"
   )
 
   for (i in seq_along(fun_fmls)) {


### PR DESCRIPTION
Using the test as a demo:

``` r
devtools::load_all("~/rrr/jadd")
#> Loading jadd

foo <- function(x, y = "a",
                ...,
                d = NULL, # comment
                k = c(2, 3),
                z = TRUE, r = as.character(z)) {
  invisible()
}

assign_defaults(foo)
#> Setting formal arguments of `foo()` to their default values
#>   x: <no assignment made>
#>   y: a
#> ...: <no assignment made>
#>   d: NULL
#>   k: c(2, 3)
#>   z: TRUE
#>   r: TRUE
```

<sup>Created on 2019-12-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>